### PR TITLE
use node 14

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,10 @@
   "name": "czechitas-app",
   "version": "1.0.0",
   "private": true,
+  "engines" : {
+    "npm" : ">=6.14.15",
+    "node" : ">=14.18.0 <15"
+  },
   "scripts": {
     "start": "cross-env NODE_ENV=development webpack --mode=development --watch",
     "debug": "cross-env NODE_ENV=development webpack --mode=development",


### PR DESCRIPTION
Hi all,
I faced issues with app deploy to heroku for Brno test academy when using default heroku node 16, so I have forced use of node 14.

Could you please check and merge it, please