### PR TITLE
Fix Heroku trusted proxies

### DIFF
--- a/app/Http/Middleware/TrustProxies.php
+++ b/app/Http/Middleware/TrustProxies.php
@@ -14,16 +14,12 @@ class TrustProxies extends Middleware
      *
      * @var array<mixed>
      */
-    protected $proxies;
+    protected $proxies = '*';
 
     /**
      * The headers that should be used to detect proxies.
      *
      * @var int
      */
-    protected $headers = Request::HEADER_X_FORWARDED_FOR |
-        Request::HEADER_X_FORWARDED_HOST |
-        Request::HEADER_X_FORWARDED_PORT |
-        Request::HEADER_X_FORWARDED_PROTO |
-        Request::HEADER_X_FORWARDED_AWS_ELB;
+    protected $headers = Request::HEADER_X_FORWARDED_AWS_ELB;
 }


### PR DESCRIPTION
Heroku has reverse proxies and load balancer etc. We have to trust them to force App use HTTPS.

See this: https://devcenter.heroku.com/articles/getting-started-with-laravel#trusting-the-load-balancer